### PR TITLE
fix: Parsing of quotes in command arguments

### DIFF
--- a/commit/commit_custom.go
+++ b/commit/commit_custom.go
@@ -25,6 +25,6 @@ func Files(files ...string) func(*types.Cmd) {
 // -m <msg>, --message=<msg>
 func Message(msg string) func(*types.Cmd) {
 	return func(g *types.Cmd) {
-		g.AddOptions(fmt.Sprintf("--message=\"%s\"", msg))
+		g.AddOptions(fmt.Sprintf("--message=%s", msg))
 	}
 }

--- a/git/base.go
+++ b/git/base.go
@@ -188,6 +188,11 @@ func StatusWithContext(ctx context.Context, options ...types.Option) (string, er
 	return command(ctx, "status", options...)
 }
 
+// Notes https://git-scm.com/docs/git-notes
+func Notes(options ...types.Option) (string, error) {
+	return command(context.Background(), "notes", options...)
+}
+
 // Raw use to execute arbitrary git commands.
 func Raw(cmd string, options ...types.Option) (string, error) {
 	return command(context.Background(), cmd, options...)

--- a/git/example_test.go
+++ b/git/example_test.go
@@ -288,10 +288,10 @@ func ExampleNotes_list() {
 }
 
 func ExampleNotes_listWithRef() {
-	out, _ := git.Notes(notes.List, notes.Ref("notes_ref"), git.CmdExecutor(cmdExecutorMock))
+	out, _ := git.Notes(notes.Ref("notes_ref"), notes.List, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Print(out)
-	// Output: git notes list --ref=notes_ref
+	// Output: git notes --ref=notes_ref list
 }
 
 func ExampleNotes_show() {

--- a/git/example_test.go
+++ b/git/example_test.go
@@ -2,8 +2,8 @@ package git_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/ldez/go-git-cmd-wrapper/v2/add"
 	"github.com/ldez/go-git-cmd-wrapper/v2/branch"
@@ -32,294 +32,294 @@ func ExampleInit() {
 	out, _ := git.Init(ginit.Bare, ginit.Quiet, ginit.Directory("foobar"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git init --bare --quiet foobar
+	// Output: name="git" args=["init","--bare","--quiet","foobar"]
 }
 
 func ExampleInitWithContext() {
 	out, _ := git.InitWithContext(context.Background(), ginit.Bare, ginit.Quiet, ginit.Directory("foobar"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git init --bare --quiet foobar
+	// Output: name="git" args=["init","--bare","--quiet","foobar"]
 }
 
 func ExamplePush() {
 	out, _ := git.Push(push.All, push.FollowTags, push.ReceivePack("aaa"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git push --all --follow-tags --receive-pack=aaa
+	// Output: name="git" args=["push","--all","--follow-tags","--receive-pack=aaa"]
 }
 
 func ExamplePushWithContext() {
 	out, _ := git.PushWithContext(context.Background(), push.All, push.FollowTags, push.ReceivePack("aaa"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git push --all --follow-tags --receive-pack=aaa
+	// Output: name="git" args=["push","--all","--follow-tags","--receive-pack=aaa"]
 }
 
 func ExamplePull() {
 	out, _ := git.Pull(pull.All, pull.Force, pull.Repository("upstream"), pull.Refspec("master"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git pull --all --force upstream master
+	// Output: name="git" args=["pull","--all","--force","upstream","master"]
 }
 
 func ExamplePullWithContext() {
 	out, _ := git.PullWithContext(context.Background(), pull.All, pull.Force, pull.Repository("upstream"), pull.Refspec("master"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git pull --all --force upstream master
+	// Output: name="git" args=["pull","--all","--force","upstream","master"]
 }
 
 func ExampleClone() {
 	out, _ := git.Clone(clone.Repository("git@github.com:ldez/go-git-cmd-wrapper.git"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git clone git@github.com:ldez/go-git-cmd-wrapper.git
+	// Output: name="git" args=["clone","git@github.com:ldez/go-git-cmd-wrapper.git"]
 }
 
 func ExampleCloneWithContext() {
 	out, _ := git.CloneWithContext(context.Background(), clone.Repository("git@github.com:ldez/go-git-cmd-wrapper.git"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git clone git@github.com:ldez/go-git-cmd-wrapper.git
+	// Output: name="git" args=["clone","git@github.com:ldez/go-git-cmd-wrapper.git"]
 }
 
 func ExampleRemote() {
 	out, _ := git.Remote(remote.Add("upstream", "git@github.com:johndoe/go-git-cmd-wrapper.git"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git remote add upstream git@github.com:johndoe/go-git-cmd-wrapper.git
+	// Output: name="git" args=["remote","add","upstream","git@github.com:johndoe/go-git-cmd-wrapper.git"]
 }
 
 func ExampleRemoteWithContext() {
 	out, _ := git.RemoteWithContext(context.Background(), remote.Add("upstream", "git@github.com:johndoe/go-git-cmd-wrapper.git"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git remote add upstream git@github.com:johndoe/go-git-cmd-wrapper.git
+	// Output: name="git" args=["remote","add","upstream","git@github.com:johndoe/go-git-cmd-wrapper.git"]
 }
 
 func ExampleFetch() {
 	out, _ := git.Fetch(fetch.NoTags, fetch.Remote("upstream"), fetch.RefSpec("myBranchName"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git fetch --no-tags upstream myBranchName
+	// Output: name="git" args=["fetch","--no-tags","upstream","myBranchName"]
 }
 
 func ExampleFetchWithContext() {
 	out, _ := git.FetchWithContext(context.Background(), fetch.NoTags, fetch.Remote("upstream"), fetch.RefSpec("myBranchName"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git fetch --no-tags upstream myBranchName
+	// Output: name="git" args=["fetch","--no-tags","upstream","myBranchName"]
 }
 
 func ExampleRebase() {
 	out, _ := git.Rebase(rebase.PreserveMerges, rebase.Branch(fmt.Sprintf("%s/%s", "upstream", "master")), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git rebase --preserve-merges upstream/master
+	// Output: name="git" args=["rebase","--preserve-merges","upstream/master"]
 }
 
 func ExampleRebaseWithContext() {
 	out, _ := git.RebaseWithContext(context.Background(), rebase.PreserveMerges, rebase.Branch(fmt.Sprintf("%s/%s", "upstream", "master")), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git rebase --preserve-merges upstream/master
+	// Output: name="git" args=["rebase","--preserve-merges","upstream/master"]
 }
 
 func ExampleCheckout() {
 	out, _ := git.Checkout(checkout.NewBranch("myBranchName"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git checkout -b myBranchName
+	// Output: name="git" args=["checkout","-b","myBranchName"]
 }
 
 func ExampleCheckoutWithContext() {
 	out, _ := git.CheckoutWithContext(context.Background(), checkout.NewBranch("myBranchName"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git checkout -b myBranchName
+	// Output: name="git" args=["checkout","-b","myBranchName"]
 }
 
 func ExampleConfig() {
 	out, _ := git.Config(config.Entry("rebase.autoSquash", "true"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git config rebase.autoSquash true
+	// Output: name="git" args=["config","rebase.autoSquash","true"]
 }
 
 func ExampleConfigWithContext() {
 	out, _ := git.ConfigWithContext(context.Background(), config.Entry("rebase.autoSquash", "true"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git config rebase.autoSquash true
+	// Output: name="git" args=["config","rebase.autoSquash","true"]
 }
 
 func ExampleBranch() {
 	out, _ := git.Branch(branch.DeleteForce, branch.BranchName("myBranch"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git branch -D myBranch
+	// Output: name="git" args=["branch","-D","myBranch"]
 }
 
 func ExampleBranchWithContext() {
 	out, _ := git.BranchWithContext(context.Background(), branch.DeleteForce, branch.BranchName("myBranch"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git branch -D myBranch
+	// Output: name="git" args=["branch","-D","myBranch"]
 }
 
 func ExampleRevParse() {
 	out, _ := git.RevParse(revparse.AbbrevRef(""), revparse.Args("HEAD"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git rev-parse --abbrev-ref HEAD
+	// Output: name="git" args=["rev-parse","--abbrev-ref","HEAD"]
 }
 
 func ExampleRevParseWithContext() {
 	out, _ := git.RevParseWithContext(context.Background(), revparse.AbbrevRef(""), revparse.Args("HEAD"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git rev-parse --abbrev-ref HEAD
+	// Output: name="git" args=["rev-parse","--abbrev-ref","HEAD"]
 }
 
 func ExampleReset() {
 	out, _ := git.Reset(reset.Soft, reset.Commit("e41f083"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git reset --soft e41f083
+	// Output: name="git" args=["reset","--soft","e41f083"]
 }
 
 func ExampleResetWithContext() {
 	out, _ := git.ResetWithContext(context.Background(), reset.Soft, reset.Commit("e41f083"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git reset --soft e41f083
+	// Output: name="git" args=["reset","--soft","e41f083"]
 }
 
 func ExampleCommit() {
 	out, _ := git.Commit(commit.Amend, commit.Message("chore: foo"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git commit --amend --message="chore: foo"
+	// Output: name="git" args=["commit","--amend","--message=chore: foo"]
 }
 
 func ExampleCommitWithContext() {
 	out, _ := git.CommitWithContext(context.Background(), commit.Amend, commit.Message("chore: foo"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git commit --amend --message="chore: foo"
+	// Output: name="git" args=["commit","--amend","--message=chore: foo"]
 }
 
 func ExampleAdd() {
 	out, _ := git.Add(add.All, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git add --all
+	// Output: name="git" args=["add","--all"]
 }
 
 func ExampleAddWithContext() {
 	out, _ := git.AddWithContext(context.Background(), add.All, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git add --all
+	// Output: name="git" args=["add","--all"]
 }
 
 func ExampleMerge() {
 	out, _ := git.Merge(merge.Squash, merge.Commits("myBranch"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git merge --squash myBranch
+	// Output: name="git" args=["merge","--squash","myBranch"]
 }
 
 func ExampleMergeWithContext() {
 	out, _ := git.MergeWithContext(context.Background(), merge.Squash, merge.Commits("myBranch"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git merge --squash myBranch
+	// Output: name="git" args=["merge","--squash","myBranch"]
 }
 
 func ExampleWorktree() {
 	out, _ := git.Worktree(worktree.Add("v1.0", "origin/v1.0"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git worktree add v1.0 origin/v1.0
+	// Output: name="git" args=["worktree","add","v1.0","origin/v1.0"]
 }
 
 func ExampleWorktreeWithContext() {
 	out, _ := git.WorktreeWithContext(context.Background(), worktree.Add("v1.0", "origin/v1.0"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git worktree add v1.0 origin/v1.0
+	// Output: name="git" args=["worktree","add","v1.0","origin/v1.0"]
 }
 
 func ExampleTag() {
 	out, _ := git.Tag(tag.List, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git tag --list
+	// Output: name="git" args=["tag","--list"]
 }
 
 func ExampleTagWithContext() {
 	out, _ := git.TagWithContext(context.Background(), tag.List, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git tag --list
+	// Output: name="git" args=["tag","--list"]
 }
 
 func ExampleStatus() {
 	out, _ := git.Status(status.Short, status.Branch, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git status --short --branch
+	// Output: name="git" args=["status","--short","--branch"]
 }
 
 func ExampleStatusWithContext() {
 	out, _ := git.StatusWithContext(context.Background(), status.Short, status.Branch, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Println(out)
-	// Output: git status --short --branch
+	// Output: name="git" args=["status","--short","--branch"]
 }
 
 func ExampleNotes_list() {
 	out, _ := git.Notes(notes.List, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Print(out)
-	// Output: git notes list
+	// Output: name="git" args=["notes","list"]
 }
 
 func ExampleNotes_listWithRef() {
 	out, _ := git.Notes(notes.Ref("notes_ref"), notes.List, git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Print(out)
-	// Output: git notes --ref=notes_ref list
+	// Output: name="git" args=["notes","--ref=notes_ref","list"]
 }
 
 func ExampleNotes_show() {
 	out, _ := git.Notes(notes.Show(""), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Print(out)
-	// Output: git notes show
+	// Output: name="git" args=["notes","show"]
 }
 
 func ExampleNotes_showObjectID() {
 	out, _ := git.Notes(notes.Show("object_id"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Print(out)
-	// Output: git notes show object_id
+	// Output: name="git" args=["notes","show","object_id"]
 }
 
 func ExampleNotes_add() {
 	out, _ := git.Notes(notes.Add, notes.Message("note message"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Print(out)
-	// Output: git notes add --message="note message"
+	// Output: name="git" args=["notes","add","--message=note message"]
 }
 
 func ExampleNotes_addForce() {
 	out, _ := git.Notes(notes.Add, notes.Force, notes.Message("note message"), git.CmdExecutor(cmdExecutorMock))
 
 	fmt.Print(out)
-	// Output: git notes add --force --message="note message"
+	// Output: name="git" args=["notes","add","--force","--message=note message"]
 }
 
 func ExampleRaw() {
@@ -329,7 +329,7 @@ func ExampleRaw() {
 	})
 
 	fmt.Println(out)
-	// Output: git stash list --pretty=format:'%Cblue%gd%Creset%Cred:%Creset %C(yellow)%s%Creset'
+	// Output: name="git" args=["stash","list","--pretty=format:'%Cblue%gd%Creset%Cred:%Creset %C(yellow)%s%Creset'"]
 }
 
 func ExampleRawWithContext() {
@@ -339,7 +339,7 @@ func ExampleRawWithContext() {
 	})
 
 	fmt.Println(out)
-	// Output: git stash list --pretty=format:'%Cblue%gd%Creset%Cred:%Creset %C(yellow)%s%Creset'
+	// Output: name="git" args=["stash","list","--pretty=format:'%Cblue%gd%Creset%Cred:%Creset %C(yellow)%s%Creset'"]
 }
 
 func ExampleCond() {
@@ -354,10 +354,16 @@ func ExampleCond() {
 	fmt.Print(out)
 
 	// Output:
-	// git push --all --follow-tags --receive-pack=aaa
-	// git push --all --dry-run --follow-tags --receive-pack=aaa
+	// name="git" args=["push","--all","--follow-tags","--receive-pack=aaa"]
+	// name="git" args=["push","--all","--dry-run","--follow-tags","--receive-pack=aaa"]
 }
 
 func cmdExecutorMock(_ context.Context, name string, _ bool, args ...string) (string, error) {
-	return fmt.Sprintln(name, strings.Join(args, " ")), nil
+
+	nameString := fmt.Sprintf("name=\"%s\"", name)
+
+	argsJSON, _ := json.Marshal(args)
+	argsString := fmt.Sprintf("args=%s", argsJSON)
+
+	return fmt.Sprintln(nameString, argsString), nil
 }

--- a/git/example_test.go
+++ b/git/example_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ldez/go-git-cmd-wrapper/v2/git"
 	ginit "github.com/ldez/go-git-cmd-wrapper/v2/init"
 	"github.com/ldez/go-git-cmd-wrapper/v2/merge"
+	"github.com/ldez/go-git-cmd-wrapper/v2/notes"
 	"github.com/ldez/go-git-cmd-wrapper/v2/pull"
 	"github.com/ldez/go-git-cmd-wrapper/v2/push"
 	"github.com/ldez/go-git-cmd-wrapper/v2/rebase"
@@ -277,6 +278,48 @@ func ExampleStatusWithContext() {
 
 	fmt.Println(out)
 	// Output: git status --short --branch
+}
+
+func ExampleNotes_list() {
+	out, _ := git.Notes(notes.List, git.CmdExecutor(cmdExecutorMock))
+
+	fmt.Print(out)
+	// Output: git notes list
+}
+
+func ExampleNotes_listWithRef() {
+	out, _ := git.Notes(notes.List, notes.Ref("notes_ref"), git.CmdExecutor(cmdExecutorMock))
+
+	fmt.Print(out)
+	// Output: git notes list --ref=notes_ref
+}
+
+func ExampleNotes_show() {
+	out, _ := git.Notes(notes.Show(""), git.CmdExecutor(cmdExecutorMock))
+
+	fmt.Print(out)
+	// Output: git notes show
+}
+
+func ExampleNotes_showObjectID() {
+	out, _ := git.Notes(notes.Show("object_id"), git.CmdExecutor(cmdExecutorMock))
+
+	fmt.Print(out)
+	// Output: git notes show object_id
+}
+
+func ExampleNotes_add() {
+	out, _ := git.Notes(notes.Add, notes.Message("note message"), git.CmdExecutor(cmdExecutorMock))
+
+	fmt.Print(out)
+	// Output: git notes add --message="note message"
+}
+
+func ExampleNotes_addForce() {
+	out, _ := git.Notes(notes.Add, notes.Force, notes.Message("note message"), git.CmdExecutor(cmdExecutorMock))
+
+	fmt.Print(out)
+	// Output: git notes add --force --message="note message"
 }
 
 func ExampleRaw() {

--- a/internal/descriptions.json
+++ b/internal/descriptions.json
@@ -1919,6 +1919,22 @@
     ]
   },
   {
+    "command_name": "notes",
+    "enabled": true,
+    "options": [
+      {
+        "argument": "--force",
+        "arguments": "--force, -f",
+        "description": "When adding notes to an object that already has notes, overwrite the existing notes (instead of aborting)."
+      },
+      {
+        "argument": "--ref=<notes-ref>",
+        "arguments": "--ref=<notes-ref>",
+        "description": "use notes from <notes-ref>"
+      }
+    ]
+  },
+  {
     "command_name": "",
     "enabled": false,
     "options": [

--- a/notes/doc.go
+++ b/notes/doc.go
@@ -1,0 +1,39 @@
+/*
+Package notes git-notes - Add or inspect object notes.
+
+SYNOPSIS
+
+Reference: https://git-scm.com/docs/git-notes
+
+		git notes [list [<object>]]
+		git notes add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]
+		git notes copy [-f] ( --stdin | <from-object> [<to-object>] )
+		git notes append [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]
+		git notes edit [--allow-empty] [<object>]
+		git notes show [<object>]
+		git notes merge [-v | -q] [-s <strategy> ] <notes-ref>
+		git notes merge --commit [-v | -q]
+		git notes merge --abort [-v | -q]
+		git notes remove [--ignore-missing] [--stdin] [<object>…​]
+		git notes prune [-n] [-v]
+		git notes get-ref
+
+DESCRIPTION
+
+Adds, removes, or reads notes attached to objects, without touching the objects themselves.
+
+By default, notes are saved to and read from refs/notes/commits, but this default can be overridden. See the OPTIONS, CONFIGURATION, and ENVIRONMENT sections below.
+If this ref does not exist, it will be quietly created when it is first needed to store a note.
+
+A typical use of notes is to supplement a commit message without changing the commit itself. Notes can be shown by git log along with the original commit message.
+To distinguish these notes from the message stored in the commit object, the notes are indented like the message, after an unindented line saying
+"Notes (<refname>):" (or "Notes:" for refs/notes/commits).
+
+Notes can also be added to patches prepared with git format-patch by using the --notes option. Such notes are added as a patch commentary after a three dash separator line.
+
+To change which notes are shown by git log, see the "notes.displayRef" configuration in git-log[1].
+
+See the "notes.rewrite.<command>" configuration for a way to carry notes across commands that rewrite commits.
+
+*/
+package notes

--- a/notes/notes_custom.go
+++ b/notes/notes_custom.go
@@ -21,7 +21,7 @@ func List(g *types.Cmd) {
 // -m <msg>, --message=<msg>
 func Message(msg string) func(*types.Cmd) {
 	return func(g *types.Cmd) {
-		g.AddOptions(fmt.Sprintf("--message=\"%s\"", msg))
+		g.AddOptions(fmt.Sprintf("--message=%s", msg))
 	}
 }
 

--- a/notes/notes_custom.go
+++ b/notes/notes_custom.go
@@ -1,0 +1,36 @@
+package notes
+
+import (
+	"fmt"
+
+	"github.com/ldez/go-git-cmd-wrapper/v2/types"
+)
+
+// Add git notes add [-f] [--allow-empty] [-F <file> | -m <msg> | (-c | -C) <object>] [<object>]
+func Add(g *types.Cmd) {
+	g.AddOptions("add")
+}
+
+// List git notes list [<object]
+func List(g *types.Cmd) {
+	g.AddOptions("list")
+}
+
+// Message Use the given <msg> as the commit message.
+// If multiple -m options are given, their values are concatenated as separate paragraphs.
+// -m <msg>, --message=<msg>
+func Message(msg string) func(*types.Cmd) {
+	return func(g *types.Cmd) {
+		g.AddOptions(fmt.Sprintf("--message=\"%s\"", msg))
+	}
+}
+
+// Show git notes show [<object]
+func Show(notesRef string) func(*types.Cmd) {
+	return func(g *types.Cmd) {
+		g.AddOptions("show")
+		if notesRef != "" {
+			g.AddOptions(notesRef)
+		}
+	}
+}

--- a/notes/notes_gen.go
+++ b/notes/notes_gen.go
@@ -1,0 +1,24 @@
+package notes
+
+// CODE GENERATED AUTOMATICALLY
+// THIS FILE MUST NOT BE EDITED BY HAND
+
+import (
+	"fmt"
+
+	"github.com/ldez/go-git-cmd-wrapper/v2/types"
+)
+
+// Force When adding notes to an object that already has notes, overwrite the existing notes (instead of aborting).
+// --force, -f
+func Force(g *types.Cmd) {
+	g.AddOptions("--force")
+}
+
+// Ref use notes from <notes-ref>
+// --ref=<notes-ref>
+func Ref(notesRef string) func(*types.Cmd) {
+	return func(g *types.Cmd) {
+		g.AddOptions(fmt.Sprintf("--ref=%s", notesRef))
+	}
+}


### PR DESCRIPTION
(This PR is created on top of https://github.com/ldez/go-git-cmd-wrapper/pull/4; best to merge that one first)

There was a problem constructing the "message" argument in the "git commit" and "git notes" call. Where on a command line you would normally use double quotes to indicate the start/end of an argument, this does not apply when executing the command in golang proving an array of arguments. 

The following code therefore was incorrect due to the extra quotes:
```
g.AddOptions(fmt.Sprintf("--message=\"%s\"", msg))
```

Example (taken from example_test.go):
```gitCmdWrapper.Commit(commit.Message("chore: foo"))```

Expected result:
Commit message is `chore: foo`

Actual result:
Commit message is: `"chore: foo"` (includes quotes)

Although the fix was easy, it was non-trivial to update example_test.go since there was no way to indicate the argument boundaries in the expected results. I chose to update the test mock to return the arguments as a marshalled JSON string, and updated all expected outcomes accordingly.