### PR TITLE
feat: add support for remote update subcommand

### DIFF
--- a/remote/remote.go
+++ b/remote/remote.go
@@ -168,3 +168,8 @@ func Mirror(option string) func(*types.Cmd) {
 		g.AddOptions(fmt.Sprintf("--mirror=%s", option))
 	}
 }
+
+// Update git remote update ... (for updating a git mirror)
+func Update(g *types.Cmd) {
+	g.AddOptions("update")
+}

--- a/remote/remote.go
+++ b/remote/remote.go
@@ -91,6 +91,16 @@ func Prune(names ...string) func(*types.Cmd) {
 	}
 }
 
+// Update Fetch updates for remotes or remote groups in the repository as defined by remotes.<group>.
+func Update(remotes ...string) func(*types.Cmd) {
+	return func(g *types.Cmd) {
+		g.AddOptions("update")
+		for _, name := range remotes {
+			g.AddOptions(name)
+		}
+	}
+}
+
 // Verbose [-v | --verbose]
 func Verbose(g *types.Cmd) {
 	g.AddOptions("--verbose")
@@ -167,9 +177,4 @@ func Mirror(option string) func(*types.Cmd) {
 	return func(g *types.Cmd) {
 		g.AddOptions(fmt.Sprintf("--mirror=%s", option))
 	}
-}
-
-// Update git remote update ... (for updating a git mirror)
-func Update(g *types.Cmd) {
-	g.AddOptions("update")
 }


### PR DESCRIPTION
I was missing the `update` subcommand for `git remote` so I added it. ([Reference](https://git-scm.com/docs/git-remote))