### PR TITLE
feat: allow to handle global option

### DIFF
--- a/git/base.go
+++ b/git/base.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log"
+	"slices"
 
 	"github.com/ldez/go-git-cmd-wrapper/v2/types"
 )
@@ -271,5 +272,5 @@ func command(ctx context.Context, name string, options ...types.Option) (string,
 	g := types.NewCmd(name)
 	g.ApplyOptions(options...)
 
-	return g.Exec(ctx, g.Base, g.Debug, g.Options...)
+	return g.Exec(ctx, g.Base, g.Debug, slices.Concat(g.BaseOptions, g.Options)...)
 }

--- a/git/example_test.go
+++ b/git/example_test.go
@@ -628,6 +628,25 @@ func ExampleRawWithContext() {
 	// Output: git stash list --pretty=format:'%Cblue%gd%Creset%Cred:%Creset %C(yellow)%s%Creset'
 }
 
+func ExampleRawWithContext_baseOptions() {
+	out, _ := git.RawWithContext(
+		context.Background(),
+		"stash",
+		func(g *types.Cmd) {
+			g.AddOptions("list")
+			g.AddOptions("--pretty=format:'%Cblue%gd%Creset%Cred:%Creset %C(yellow)%s%Creset'")
+		},
+		func(g *types.Cmd) {
+			g.AddBaseOptions("-C")
+			g.AddBaseOptions("<your_path>")
+		},
+		git.CmdExecutor(cmdExecutorMock),
+	)
+
+	fmt.Println(out)
+	// Output: git -C <your_path> stash list --pretty=format:'%Cblue%gd%Creset%Cred:%Creset %C(yellow)%s%Creset'
+}
+
 func ExampleCond() {
 	param := false
 	out, _ := git.Push(push.All, git.Cond(param, push.DryRun), push.FollowTags, push.ReceivePack("aaa"), git.CmdExecutor(cmdExecutorMock))

--- a/types/types.go
+++ b/types/types.go
@@ -21,11 +21,12 @@ type Executor func(ctx context.Context, name string, debug bool, args ...string)
 
 // Cmd Command.
 type Cmd struct {
-	Debug    bool
-	Base     string
-	Options  []string
-	Logger   logger
-	Executor Executor
+	Debug       bool
+	Base        string
+	BaseOptions []string
+	Options     []string
+	Logger      logger
+	Executor    Executor
 }
 
 // NewCmd Creates a new Cmd.
@@ -47,6 +48,11 @@ type Option func(g *Cmd)
 // AddOptions Add one command option.
 func (g *Cmd) AddOptions(option string) {
 	g.Options = append(g.Options, option)
+}
+
+// AddBaseOptions Add one global command option.
+func (g *Cmd) AddBaseOptions(option string) {
+	g.BaseOptions = append(g.BaseOptions, option)
 }
 
 // ApplyOptions Apply command options.


### PR DESCRIPTION
Fixes #12

Examples:

```go
func foo()  {
	_, _ = git.Push(
		func(g *types.Cmd) {
			g.AddBaseOptions("-C")
			g.AddBaseOptions("<your_path>")
		},
	)
}

// git -C <your_path> push
```

or

```go
func foo() {
	_, _ = git.Push(C("<your_path>"))
}

func C(p string) types.Option {
	return func(g *types.Cmd) {
		g.AddBaseOptions("-C")
		g.AddBaseOptions(p)
	}
}

// git -C <your_path> push
```

For now, I didn't create the global options mapping like for the sub commands (`push`, `pull`, etc.) because I need to think more about the right approach.
